### PR TITLE
Fixed the bundleID to be able to compile

### DIFF
--- a/source/pdxinfo
+++ b/source/pdxinfo
@@ -1,7 +1,7 @@
 name=QwarioWare
 author=q42
 description=crowd-developed minigame collection!
-bundleID=q42.qwarioware
+bundleID=nl.q42.qwarioware
 version=0.1
 imagePath=launcher/
 launchSoundPath=launcher/


### PR DESCRIPTION
This fixes the following error:
> error: Metadata bundle ID not in reverse DNS format (ex: com.panic.b360)